### PR TITLE
Get rid of annoying errors in exception.log

### DIFF
--- a/app/code/community/Inchoo/SocialConnect/Block/Login.php
+++ b/app/code/community/Inchoo/SocialConnect/Block/Login.php
@@ -73,7 +73,9 @@ class Inchoo_SocialConnect_Block_Login extends Mage_Core_Block_Template
             $this->numEnabled++;
         }
 
-        Mage::register('inchoo_socialconnect_button_text', $this->__('Login'));
+        if(!(Mage::registry('inchoo_socialconnect_button_text'))) {
+            Mage::register('inchoo_socialconnect_button_text', $this->__('Login'));
+        }
 
         $this->setTemplate('inchoo/socialconnect/login.phtml');
     }


### PR DESCRIPTION
Check if the registry key is already there before trying to set it.
