### PR TITLE
Use escapeHtml() function instead of deprecated htmlEscape() function

### DIFF
--- a/app/code/community/Inchoo/SocialConnect/Block/Facebook/Account.php
+++ b/app/code/community/Inchoo/SocialConnect/Block/Facebook/Account.php
@@ -72,7 +72,7 @@ class Inchoo_SocialConnect_Block_Facebook_Account extends Mage_Core_Block_Templa
     {
         if($this->userInfo->getLink()) {
             $link = '<a href="'.$this->userInfo->getLink().'" target="_blank">'.
-                    $this->htmlEscape($this->userInfo->getName()).'</a>';
+                    $this->escapeHtml($this->userInfo->getName()).'</a>';
         } else {
             $link = $this->userInfo->getName();
         }

--- a/app/code/community/Inchoo/SocialConnect/Block/Google/Account.php
+++ b/app/code/community/Inchoo/SocialConnect/Block/Google/Account.php
@@ -73,7 +73,7 @@ class Inchoo_SocialConnect_Block_Google_Account extends Mage_Core_Block_Template
     {
         if($this->userInfo->getLink()) {
             $link = '<a href="'.$this->userInfo->getLink().'" target="_blank">'.
-                    $this->htmlEscape($this->userInfo->getName()).'</a>';
+                    $this->escapeHtml($this->userInfo->getName()).'</a>';
         } else {
             $link = $this->userInfo->getName();
         }

--- a/app/code/community/Inchoo/SocialConnect/Block/Linkedin/Account.php
+++ b/app/code/community/Inchoo/SocialConnect/Block/Linkedin/Account.php
@@ -73,7 +73,7 @@ class Inchoo_SocialConnect_Block_Linkedin_Account extends Mage_Core_Block_Templa
         $siteStandardProfileRequest = $this->userInfo->getSiteStandardProfileRequest();
         if($siteStandardProfileRequest && !empty($siteStandardProfileRequest->url)) {
             $link = '<a href="'.$siteStandardProfileRequest->url.'" target="_blank">'.
-                    $this->htmlEscape($this->_getName()).'</a>';
+                    $this->escapeHtml($this->_getName()).'</a>';
         } else {
             $link = $this->_getName();
         }
@@ -85,7 +85,7 @@ class Inchoo_SocialConnect_Block_Linkedin_Account extends Mage_Core_Block_Templa
     {
         if($this->userInfo->getPublicProfileUrl()) {
             $link = '<a href="'.$this->userInfo->getPublicProfileUrl().'" target="_blank">'.
-                    $this->htmlEscape($this->userInfo->getPublicProfileUrl()).'</a>';
+                    $this->escapeHtml($this->userInfo->getPublicProfileUrl()).'</a>';
 
             return $link;
         }

--- a/app/code/community/Inchoo/SocialConnect/Block/Twitter/Account.php
+++ b/app/code/community/Inchoo/SocialConnect/Block/Twitter/Account.php
@@ -73,7 +73,7 @@ class Inchoo_SocialConnect_Block_Twitter_Account extends Mage_Core_Block_Templat
     protected function _getStatus()
     {
         return '<a href="'.sprintf('https://twitter.com/%s', $this->userInfo->getScreenName()).'" target="_blank">'.
-                    $this->htmlEscape($this->userInfo->getScreenName()).'</a>';
+                    $this->escapeHtml($this->userInfo->getScreenName()).'</a>';
     }
 
     protected function _getPicture()

--- a/app/design/frontend/base/default/template/inchoo/socialconnect/checkout/onepage/login.phtml
+++ b/app/design/frontend/base/default/template/inchoo/socialconnect/checkout/onepage/login.phtml
@@ -80,7 +80,7 @@
                 <li>
                     <label for="login-email" class="required"><em>*</em><?php echo $this->__('Email Address') ?></label>
                     <div class="input-box">
-                        <input type="text" class="input-text required-entry validate-email" id="login-email" name="login[username]" value="<?php echo $this->htmlEscape($this->getUsername()) ?>" />
+                        <input type="text" class="input-text required-entry validate-email" id="login-email" name="login[username]" value="<?php echo $this->escapeHtml($this->getUsername()) ?>" />
                     </div>
                 </li>
                 <li>

--- a/app/design/frontend/base/default/template/inchoo/socialconnect/facebook/account.phtml
+++ b/app/design/frontend/base/default/template/inchoo/socialconnect/facebook/account.phtml
@@ -54,7 +54,7 @@
                 <div class="col-1">
                     <?php if(!empty($picture)): ?>
                     <p>
-                        <img src="<?php echo $picture; ?>" alt="<?php echo $this->htmlEscape($name); ?>" />
+                        <img src="<?php echo $picture; ?>" alt="<?php echo $this->escapeHtml($name); ?>" />
                     </p>
                     <?php endif; ?>
                 </div>

--- a/app/design/frontend/base/default/template/inchoo/socialconnect/google/account.phtml
+++ b/app/design/frontend/base/default/template/inchoo/socialconnect/google/account.phtml
@@ -54,7 +54,7 @@
                 <div class="col-1">
                     <?php if(!empty($picture)): ?>
                     <p>
-                        <img src="<?php echo $picture; ?>" alt="<?php echo $this->htmlEscape($name); ?>" />
+                        <img src="<?php echo $picture; ?>" alt="<?php echo $this->escapeHtml($name); ?>" />
                     </p>
                     <?php endif; ?>
                 </div>

--- a/app/design/frontend/base/default/template/inchoo/socialconnect/linkedin/account.phtml
+++ b/app/design/frontend/base/default/template/inchoo/socialconnect/linkedin/account.phtml
@@ -55,7 +55,7 @@
                     <div class="col-1">
                         <?php if(!empty($picture)): ?>
                         <p>
-                            <img src="<?php echo $picture; ?>" alt="<?php echo $this->htmlEscape($name); ?>" />
+                            <img src="<?php echo $picture; ?>" alt="<?php echo $this->escapeHtml($name); ?>" />
                         </p>
                         <?php endif; ?>
                     </div>

--- a/app/design/frontend/base/default/template/inchoo/socialconnect/twitter/account.phtml
+++ b/app/design/frontend/base/default/template/inchoo/socialconnect/twitter/account.phtml
@@ -51,7 +51,7 @@
                 <div class="col-1">
                     <?php if(!empty($picture)): ?>
                     <p>
-                        <img src="<?php echo $picture; ?>" alt="<?php echo $this->htmlEscape($name); ?>" />
+                        <img src="<?php echo $picture; ?>" alt="<?php echo $this->escapeHtml($name); ?>" />
                     </p>
                     <?php endif; ?>
                 </div>


### PR DESCRIPTION
In 1.8.1.0 release of Magento all calls to htmlEscape() function were replaced with calls to escapeHtml()
I think it's a good idea to follow this changes in the extension.
htmlEscape() was deprecated in 1.4.0.0-rc1 release
