### PR TITLE
Removed undefined method _sessionCleanup()

### DIFF
--- a/app/code/community/Inchoo/SocialConnect/controllers/TwitterController.php
+++ b/app/code/community/Inchoo/SocialConnect/controllers/TwitterController.php
@@ -19,8 +19,6 @@ class Inchoo_SocialConnect_TwitterController extends Inchoo_SocialConnect_Contro
             Mage::getSingleton('core/session')->addError($e->getMessage());
             Mage::logException($e);
 
-            $this->_sessionCleanup();
-
             if(!empty($referer)) {
                 $this->_redirectUrl($referer);
             } else {


### PR DESCRIPTION
In `app/code/community/Inchoo/SocialConnect/controllers/TwitterController.php` there's a function call on line 22:

``` php
$this->_sessionCleanup();
```

But that method doesn't exist. I've checked Magento 1.5, 1.8 & 1.9 but I can't find that method. So when I try to use the Twitter login and an exception is thrown I get this error:

```
Call to undefined method Inchoo_SocialConnect_TwitterController::_sessionCleanup()
```