### PR TITLE
Fix: Issue #40 - Error in facebook login

### DIFF
--- a/app/code/community/Inchoo/SocialConnect/Model/Facebook/Info.php
+++ b/app/code/community/Inchoo/SocialConnect/Model/Facebook/Info.php
@@ -90,6 +90,7 @@ class Inchoo_SocialConnect_Model_Facebook_Info extends Varien_Object
 
     protected function _load()
     {
+	$this->params['fields'] = 'first_name,last_name,email';
         try{
             $response = $this->client->api(
                 '/me',


### PR DESCRIPTION
Changes:
specify exactly which fields we need when calling /me since facebook wasn't returning enough info otherwise

This is a patch for issue #40 - might not be a long term solution, but makes sure we are getting the proper fields from the api call.