### PR TITLE
Fix the way a list of required fields is sent to /me endpoint in Graph API

### DIFF
--- a/app/code/community/Inchoo/SocialConnect/Model/Facebook/Info.php
+++ b/app/code/community/Inchoo/SocialConnect/Model/Facebook/Info.php
@@ -104,7 +104,7 @@ class Inchoo_SocialConnect_Model_Facebook_Info extends Varien_Object
             $response = $this->client->api(
                 '/me',
                 'GET',
-                $this->params
+                array('fields' => implode(',', $this->params))
             );
 
             foreach ($response as $key => $value) {


### PR DESCRIPTION
Currently extension sends the list of fields to /me endpoint as multiple query parameters, which is not correct according Graph API documentation. It breaks login/registration with Facebook, because in that case API returns only _id_ and _name_ fields for a user profile, which is not sufficient to create Magento account.

Graph API documentation: https://developers.facebook.com/docs/graph-api/using-graph-api/v2.5#fields

The fix converts the list into comma-separated string and supplies it as a _fields_ parameter into Graph API