### PR TITLE
fix birthday informations from facebook: birthday is empty if permiss…

### DIFF
--- a/app/code/community/Inchoo/SocialConnect/controllers/FacebookController.php
+++ b/app/code/community/Inchoo/SocialConnect/controllers/FacebookController.php
@@ -149,9 +149,13 @@ class Inchoo_SocialConnect_FacebookController extends Inchoo_SocialConnect_Contr
                 );
             }
 
-            $birthday = $info->getBirthday();
-            $birthday = Mage::app()->getLocale()->date($birthday, null, null, false)
+            $birthday = null;
+            // birthday is empty if user denies the permission
+            if(!empty($info->getBirthday())) {
+                $birthday = $info->getBirthday();
+                $birthday = Mage::app()->getLocale()->date($birthday, "MM/dd/yyyy", null, false)
                 ->toString('yyyy-MM-dd');
+            }
 
             $gender = $info->getGender();
             if(empty($gender)) {


### PR DESCRIPTION
…ion is denied (therefore it was be converted to current date) + fix date format

Facebook's date format is american (MM/dd/yyyy) and have to be given to the date method to convert correctly. See the comment from chougron in the old PR #22, which had the same issue.