### PR TITLE
Fix wrong customer birthday

### DIFF
--- a/app/code/community/Inchoo/SocialConnect/controllers/FacebookController.php
+++ b/app/code/community/Inchoo/SocialConnect/controllers/FacebookController.php
@@ -149,10 +149,11 @@ class Inchoo_SocialConnect_FacebookController extends Inchoo_SocialConnect_Contr
                 );
             }
 
-            $birthday = $info->getBirthday();
-            $birthday = Mage::app()->getLocale()->date($birthday, null, null, false)
-                ->toString('yyyy-MM-dd');
-
+            $birthday = null;
+            if (!empty($info->getBirthday())) {
+                $birthday = Mage::app()->getLocale()->date($info->getBirthday(), null, null, false)
+                    ->toString('yyyy-MM-dd');
+            }
             $gender = $info->getGender();
             if(empty($gender)) {
                 $gender = null;


### PR DESCRIPTION
The birthday could be empty if Facebook user did not give his permission to use it.
In this case the birthday is set to the current date, which may run into conflicts with payment providers for example, which check, if the customer is an adult.