### PR TITLE
Make two buttons possible/avoid AJAX refreshes CSRF

### DIFF
--- a/app/code/community/Inchoo/SocialConnect/Block/Facebook/Button.php
+++ b/app/code/community/Inchoo/SocialConnect/Block/Facebook/Button.php
@@ -4,15 +4,20 @@
  *
  * Commercial support is available directly from the [extension author](http://www.techytalk.info/contact/).
  *
- * @category Marko-M
- * @package SocialConnect
- * @author Marko Martinović <marko@techytalk.info>
+ * @category  Marko-M
+ * @package   SocialConnect
+ * @author    Marko Martinović <marko@techytalk.info>
  * @copyright Copyright (c) Marko Martinović (http://www.techytalk.info)
- * @license http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
 
 class Inchoo_SocialConnect_Block_Facebook_Button extends Mage_Core_Block_Template
 {
+    /**
+     * @var string
+     */
+    protected static $csrf;
+
     /**
      *
      * @var Inchoo_SocialConnect_Model_Facebook_Oauth2_Client
@@ -35,14 +40,22 @@ class Inchoo_SocialConnect_Block_Facebook_Button extends Mage_Core_Block_Templat
 
         $this->userInfo = Mage::registry('inchoo_socialconnect_facebook_userinfo');
 
-        // CSRF protection
-        Mage::getSingleton('core/session')->setFacebookCsrf($csrf = md5(uniqid(rand(), true)));
-        $this->client->setState($csrf);
-
         Mage::getSingleton('customer/session')
             ->setSocialConnectRedirect(Mage::helper('core/url')->getCurrentUrl());
 
         $this->setTemplate('inchoo/socialconnect/facebook/button.phtml');
+    }
+
+    protected function _beforeToHtml()
+    {
+        if (!static::$csrf) {
+            static::$csrf = Mage::getSingleton('core/session')->getFacebookCsrf();
+        }
+        // CSRF protection
+        Mage::getSingleton('core/session')->setFacebookCsrf(static::$csrf);
+        $this->client->setState(static::$csrf);
+
+        return parent::_beforeToHtml();
     }
 
     protected function _getButtonUrl()

--- a/app/code/community/Inchoo/SocialConnect/Block/Facebook/Button.php
+++ b/app/code/community/Inchoo/SocialConnect/Block/Facebook/Button.php
@@ -49,7 +49,7 @@ class Inchoo_SocialConnect_Block_Facebook_Button extends Mage_Core_Block_Templat
     protected function _beforeToHtml()
     {
         if (!static::$csrf) {
-            static::$csrf = Mage::getSingleton('core/session')->getFacebookCsrf();
+            static::$csrf = md5(uniqid(mt_rand(), true));
         }
         // CSRF protection
         Mage::getSingleton('core/session')->setFacebookCsrf(static::$csrf);

--- a/app/code/community/Inchoo/SocialConnect/Block/Google/Button.php
+++ b/app/code/community/Inchoo/SocialConnect/Block/Google/Button.php
@@ -50,7 +50,7 @@ class Inchoo_SocialConnect_Block_Google_Button extends Mage_Core_Block_Template
     protected function _beforeToHtml()
     {
         if (!static::$csrf) {
-            static::$csrf = Mage::getSingleton('core/session')->getGoogleCsrf();
+            static::$csrf = md5(uniqid(mt_rand(), true));
         }
         // CSRF protection
         Mage::getSingleton('core/session')->setGoogleCsrf(static::$csrf);

--- a/app/code/community/Inchoo/SocialConnect/Block/Google/Button.php
+++ b/app/code/community/Inchoo/SocialConnect/Block/Google/Button.php
@@ -14,6 +14,11 @@
 class Inchoo_SocialConnect_Block_Google_Button extends Mage_Core_Block_Template
 {
     /**
+     * @var string
+     */
+    protected static $csrf;
+
+    /**
      *
      * @var Inchoo_SocialConnect_Model_Google_Oauth2_Client
      */
@@ -35,15 +40,25 @@ class Inchoo_SocialConnect_Block_Google_Button extends Mage_Core_Block_Template
 
         $this->userInfo = Mage::registry('inchoo_socialconnect_google_userinfo');
 
-        // CSRF protection
-        Mage::getSingleton('core/session')->setGoogleCsrf($csrf = md5(uniqid(rand(), true)));
-        $this->client->setState($csrf);
-
         Mage::getSingleton('customer/session')
             ->setSocialConnectRedirect(Mage::helper('core/url')->getCurrentUrl());
 
         $this->setTemplate('inchoo/socialconnect/google/button.phtml');
     }
+
+
+    protected function _beforeToHtml()
+    {
+        if (!static::$csrf) {
+            static::$csrf = Mage::getSingleton('core/session')->getGoogleCsrf();
+        }
+        // CSRF protection
+        Mage::getSingleton('core/session')->setGoogleCsrf(static::$csrf);
+        $this->client->setState(static::$csrf);
+
+        return parent::_beforeToHtml();
+    }
+
 
     protected function _getButtonUrl()
     {

--- a/app/code/community/Inchoo/SocialConnect/Block/Linkedin/Button.php
+++ b/app/code/community/Inchoo/SocialConnect/Block/Linkedin/Button.php
@@ -49,7 +49,7 @@ class Inchoo_SocialConnect_Block_Linkedin_Button extends Mage_Core_Block_Templat
     protected function _beforeToHtml()
     {
         if (!static::$csrf) {
-            static::$csrf = Mage::getSingleton('core/session')->getLinkedinCsrf();
+            static::$csrf = md5(uniqid(mt_rand(), true));
         }
         // CSRF protection
         Mage::getSingleton('core/session')->setLinkedinCsrf($csrf = md5(uniqid(rand(), true)));

--- a/app/code/community/Inchoo/SocialConnect/Block/Linkedin/Button.php
+++ b/app/code/community/Inchoo/SocialConnect/Block/Linkedin/Button.php
@@ -52,8 +52,8 @@ class Inchoo_SocialConnect_Block_Linkedin_Button extends Mage_Core_Block_Templat
             static::$csrf = md5(uniqid(mt_rand(), true));
         }
         // CSRF protection
-        Mage::getSingleton('core/session')->setLinkedinCsrf($csrf = md5(uniqid(rand(), true)));
-        $this->client->setState($csrf);
+        Mage::getSingleton('core/session')->setLinkedinCsrf(static::$csrf);
+        $this->client->setState(static::$csrf);
 
         return parent::_beforeToHtml();
     }

--- a/app/code/community/Inchoo/SocialConnect/Block/Linkedin/Button.php
+++ b/app/code/community/Inchoo/SocialConnect/Block/Linkedin/Button.php
@@ -14,6 +14,11 @@
 class Inchoo_SocialConnect_Block_Linkedin_Button extends Mage_Core_Block_Template
 {
     /**
+     * @var string
+     */
+    protected static $csrf;
+
+    /**
      *
      * @var Inchoo_SocialConnect_Model_Linkedin_Oauth2_Client 
      */
@@ -35,14 +40,22 @@ class Inchoo_SocialConnect_Block_Linkedin_Button extends Mage_Core_Block_Templat
 
         $this->userInfo = Mage::registry('inchoo_socialconnect_linkedin_userinfo');
 
-        // CSRF protection
-        Mage::getSingleton('core/session')->setLinkedinCsrf($csrf = md5(uniqid(rand(), true)));
-        $this->client->setState($csrf);
-
         Mage::getSingleton('customer/session')
             ->setSocialConnectRedirect(Mage::helper('core/url')->getCurrentUrl());
 
         $this->setTemplate('inchoo/socialconnect/linkedin/button.phtml');
+    }
+
+    protected function _beforeToHtml()
+    {
+        if (!static::$csrf) {
+            static::$csrf = Mage::getSingleton('core/session')->getLinkedinCsrf();
+        }
+        // CSRF protection
+        Mage::getSingleton('core/session')->setLinkedinCsrf($csrf = md5(uniqid(rand(), true)));
+        $this->client->setState($csrf);
+
+        return parent::_beforeToHtml();
     }
 
     protected function _getButtonUrl()


### PR DESCRIPTION
FIXES #93 
FIXES #92 

Make it possible to have more than one button per type on the page and
make sure that an AJAX request does not refresh the CSRF token if the
button is not shown.

@Marko-M If I have some time over, I'm happy to dig through the issues and clean them up a bit. Not sure how much time I have to offer, but maybe better than currently 😅 